### PR TITLE
Add Tesla T4 support, SDPA fallback, and Gradio demo

### DIFF
--- a/audio_tokenizer/audio_encoder.py
+++ b/audio_tokenizer/audio_encoder.py
@@ -7,11 +7,9 @@ from transformers.cache_utils import DynamicCache
 
 try:
     from flash_attn import flash_attn_func
+    HAS_FLASH_ATTN = True
 except (ImportError, RuntimeError, OSError):
-    raise ImportError(
-        "Flash Attention is a required dependency but could not be imported.\n"
-        "Please check your installation and environment compatibility (e.g., CUDA version).\n"
-    )
+    HAS_FLASH_ATTN = False
 
 
 class LayerNorm(nn.LayerNorm):
@@ -78,8 +76,13 @@ class MultiHeadAttention(nn.Module):
         if past_key_values is not None:
             k, v = past_key_values.update(k, v, self.layer_idx, {"cache_position": cache_position})
 
-        a = flash_attn_func(q.permute(0, 2, 1, 3), k.permute(0, 2, 1, 3), v.permute(0, 2, 1, 3), causal=True)
-        out = a.flatten(start_dim=2)
+        if HAS_FLASH_ATTN:
+            a = flash_attn_func(q.permute(0, 2, 1, 3), k.permute(0, 2, 1, 3), v.permute(0, 2, 1, 3), causal=True)
+            out = a.flatten(start_dim=2)
+        else:
+            # Native PyTorch SDPA (T4 friendly)
+            a = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+            out = a.transpose(1, 2).contiguous().flatten(start_dim=2)
         qk = None
 
         return out, qk, past_key_values

--- a/cookbooks/test.py
+++ b/cookbooks/test.py
@@ -84,20 +84,14 @@ def set_attn_backend(config_like, backend: str):
     config_like._attn_implementation = backend
 
 
-def resolve_qwen_attention_backend(device, prefer_flash: bool = True) -> str:
-    if not device.startswith("cuda"):
-        return "eager"
+def resolve_qwen_attention_backend(device) -> str:
     if not torch.cuda.is_bf16_supported(including_emulation=False):
         return "eager"
-    if prefer_flash:
-        try:
-            import flash_attn  # noqa: F401
-            return "flash_attention_2"
-        except Exception:
-            pass
-    if hasattr(torch.nn.functional, "scaled_dot_product_attention"):
+    try:
+        import flash_attn  # noqa: F401
+        return "flash_attention_2"
+    except ImportError:
         return "sdpa"
-    return "eager"
 
 
 class MingAudio:

--- a/cookbooks/test.py
+++ b/cookbooks/test.py
@@ -62,15 +62,26 @@ BASE_CAPTION_TEMPLATE = {
 }
 
 
+def resolve_llm_dtype(device):
+    if device.startswith("cuda"):
+        return (
+            torch.bfloat16
+            if torch.cuda.is_bf16_supported(including_emulation=False)
+            else torch.float32
+        )
+    return torch.float32
+
+
 class MingAudio:
     def __init__(self, model_path, device="cuda:0"):
         self.device = device
+        self.llm_dtype = resolve_llm_dtype(device)
         self.model = BailingMMNativeForConditionalGeneration.from_pretrained(
             model_path,
-            torch_dtype=torch.bfloat16,
+            torch_dtype=self.llm_dtype,
             low_cpu_mem_usage=True,
         )
-        self.model = self.model.eval().to(torch.bfloat16).to(self.device)
+        self.model = self.model.eval().to(self.llm_dtype).to(self.device)
 
         if self.model.model_type == 'dense':
             self.tokenizer = AutoTokenizer.from_pretrained(model_path)
@@ -164,7 +175,7 @@ class MingAudio:
         if prompt_wav_path is None:
             prompt_waveform, prompt_text, spk_emb = None, None, None
             if use_zero_spk_emb:
-                spk_emb = [torch.zeros(1, 192, device=self.device, dtype=torch.bfloat16)]
+                spk_emb = [torch.zeros(1, 192, device=self.device, dtype=self.llm_dtype)]
         else:
             paths = prompt_wav_path if isinstance(prompt_wav_path, list) else [prompt_wav_path]
             processed_prompts = [self.preprocess_one_prompt_wav(p, use_spk_emb) for p in paths]

--- a/cookbooks/test.py
+++ b/cookbooks/test.py
@@ -97,28 +97,37 @@ def resolve_qwen_attention_backend(device) -> str:
 class MingAudio:
     def __init__(self, model_path, device="cuda:0"):
         self.device = device
-        self.llm_dtype = resolve_llm_dtype(device)
         local_model_path = model_path if os.path.isdir(model_path) else snapshot_download(repo_id=model_path)
         config = BailingMMConfig.from_pretrained(local_model_path)
-        set_attn_backend(config, "eager")
-        qwen_attn_impl = resolve_qwen_attention_backend(device, prefer_flash=True)
-        set_attn_backend(config.llm_config, qwen_attn_impl)
+        if config.model_type == 'dense':
+            self.llm_dtype = resolve_llm_dtype(device)
+            set_attn_backend(config, "eager")
+            qwen_attn_impl = resolve_qwen_attention_backend(device)
+            set_attn_backend(config.llm_config, qwen_attn_impl)
 
-        if hasattr(config, "audio_tokenizer_config"):
-            if hasattr(config.audio_tokenizer_config, "enc_kwargs"):
-                if "backbone" in config.audio_tokenizer_config.enc_kwargs:
-                    set_attn_backend(config.audio_tokenizer_config.enc_kwargs["backbone"], qwen_attn_impl)
-            if hasattr(config.audio_tokenizer_config, "dec_kwargs"):
-                if "backbone" in config.audio_tokenizer_config.dec_kwargs:
-                    set_attn_backend(config.audio_tokenizer_config.dec_kwargs["backbone"], qwen_attn_impl)
+            if hasattr(config, "audio_tokenizer_config"):
+                if hasattr(config.audio_tokenizer_config, "enc_kwargs"):
+                    if "backbone" in config.audio_tokenizer_config.enc_kwargs:
+                        set_attn_backend(config.audio_tokenizer_config.enc_kwargs["backbone"], qwen_attn_impl)
+                if hasattr(config.audio_tokenizer_config, "dec_kwargs"):
+                    if "backbone" in config.audio_tokenizer_config.dec_kwargs:
+                        set_attn_backend(config.audio_tokenizer_config.dec_kwargs["backbone"], qwen_attn_impl)
 
-        self.model = BailingMMNativeForConditionalGeneration.from_pretrained(
-            local_model_path,
-            config=config,
-            torch_dtype=self.llm_dtype,
-            low_cpu_mem_usage=True,
-        )
-        self.model = self.model.eval().to(self.llm_dtype).to(self.device)
+            self.model = BailingMMNativeForConditionalGeneration.from_pretrained(
+                local_model_path,
+                config=config,
+                torch_dtype=self.llm_dtype,
+                low_cpu_mem_usage=True,
+            )
+            self.model = self.model.eval().to(self.llm_dtype).to(self.device)
+        else:
+            self.llm_dtype = torch.bfloat16
+            self.model = BailingMMNativeForConditionalGeneration.from_pretrained(
+                local_model_path,
+                torch_dtype=self.llm_dtype,
+                low_cpu_mem_usage=True,
+            )
+            self.model = self.model.eval().to(self.llm_dtype).to(self.device)
 
         if self.model.model_type == 'dense':
             self.tokenizer = AutoTokenizer.from_pretrained(local_model_path)
@@ -259,6 +268,8 @@ class MingAudio:
 
 
 if __name__ == "__main__":
+    # Dense 0.5B automatically falls back to float32 on non-bf16 CUDA GPUs such as T4.
+    # MoE loading and inference remain unchanged.
     model = MingAudio("inclusionAI/Ming-omni-tts-0.5B")
     # model = MingAudio("inclusionAI/Ming-omni-tta-0.5B")  # Only for TTA task
     # model = MingAudio("inclusionAI/Ming-omni-tts-16.8B-A3B")

--- a/cookbooks/test.py
+++ b/cookbooks/test.py
@@ -18,6 +18,7 @@ parent_dir = os.path.dirname(current_dir)
 sys.path.append(parent_dir)
 
 from modeling_bailingmm import BailingMMNativeForConditionalGeneration
+from configuration_bailingmm import BailingMMConfig
 from sentence_manager.sentence_manager import SentenceNormalizer
 from spkemb_extractor import SpkembExtractor
 
@@ -72,27 +73,67 @@ def resolve_llm_dtype(device):
     return torch.float32
 
 
+def set_attn_backend(config_like, backend: str):
+    if config_like is None:
+        return
+    if isinstance(config_like, dict):
+        config_like["attn_implementation"] = backend
+        config_like["_attn_implementation"] = backend
+        return
+    config_like.attn_implementation = backend
+    config_like._attn_implementation = backend
+
+
+def resolve_qwen_attention_backend(device, prefer_flash: bool = True) -> str:
+    if not device.startswith("cuda"):
+        return "eager"
+    if not torch.cuda.is_bf16_supported(including_emulation=False):
+        return "eager"
+    if prefer_flash:
+        try:
+            import flash_attn  # noqa: F401
+            return "flash_attention_2"
+        except Exception:
+            pass
+    if hasattr(torch.nn.functional, "scaled_dot_product_attention"):
+        return "sdpa"
+    return "eager"
+
+
 class MingAudio:
     def __init__(self, model_path, device="cuda:0"):
         self.device = device
         self.llm_dtype = resolve_llm_dtype(device)
+        local_model_path = model_path if os.path.isdir(model_path) else snapshot_download(repo_id=model_path)
+        config = BailingMMConfig.from_pretrained(local_model_path)
+        set_attn_backend(config, "eager")
+        qwen_attn_impl = resolve_qwen_attention_backend(device, prefer_flash=True)
+        set_attn_backend(config.llm_config, qwen_attn_impl)
+
+        if hasattr(config, "audio_tokenizer_config"):
+            if hasattr(config.audio_tokenizer_config, "enc_kwargs"):
+                if "backbone" in config.audio_tokenizer_config.enc_kwargs:
+                    set_attn_backend(config.audio_tokenizer_config.enc_kwargs["backbone"], qwen_attn_impl)
+            if hasattr(config.audio_tokenizer_config, "dec_kwargs"):
+                if "backbone" in config.audio_tokenizer_config.dec_kwargs:
+                    set_attn_backend(config.audio_tokenizer_config.dec_kwargs["backbone"], qwen_attn_impl)
+
         self.model = BailingMMNativeForConditionalGeneration.from_pretrained(
-            model_path,
+            local_model_path,
+            config=config,
             torch_dtype=self.llm_dtype,
             low_cpu_mem_usage=True,
         )
         self.model = self.model.eval().to(self.llm_dtype).to(self.device)
 
         if self.model.model_type == 'dense':
-            self.tokenizer = AutoTokenizer.from_pretrained(model_path)
+            self.tokenizer = AutoTokenizer.from_pretrained(local_model_path)
         else:
             self.tokenizer = AutoTokenizer.from_pretrained(".", trust_remote_code=True)
         self.model.tokenizer = self.tokenizer
         self.sample_rate = self.model.config.audio_tokenizer_config.sample_rate
         self.patch_size = self.model.config.ditar_config['patch_size']
         self.normalizer = self.init_tn_normalizer(tokenizer=self.tokenizer)
-
-        local_model_path = model_path if os.path.isdir(model_path) else snapshot_download(repo_id=model_path)
         self.spkemb_extractor = SpkembExtractor(f"{local_model_path}/campplus.onnx")
 
 

--- a/gradio_demo.py
+++ b/gradio_demo.py
@@ -1,0 +1,666 @@
+import os
+import json
+import random
+import copy
+import re
+import yaml
+import uuid
+from pathlib import Path
+
+import torch
+import torchaudio
+import gradio as gr
+import numpy as np
+from transformers import AutoTokenizer
+from huggingface_hub import snapshot_download
+
+from modeling_bailingmm import BailingMMNativeForConditionalGeneration
+from configuration_bailingmm import BailingMMConfig
+from sentence_manager.sentence_manager import SentenceNormalizer
+from spkemb_extractor import SpkembExtractor
+
+# All model IDs from cookbook / test.py
+MODEL_CHOICES = [
+    "inclusionAI/Ming-omni-tts-0.5B",        # Dense — TTS + TTA + BGM
+    "inclusionAI/Ming-omni-tts-16.8B-A3B",    # MoE   — TTS + TTA + BGM (no TN)
+    "inclusionAI/Ming-omni-tta-0.5B",          # Dense — TTA only
+]
+DEFAULT_MODEL = MODEL_CHOICES[0]
+
+OUTPUT_DIR = Path("outputs")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+MODEL_CACHE = {"model": None, "key": None}
+
+BASE_CAPTION_TEMPLATE = {
+    "audio_sequence": [
+        {
+            "序号": 1,
+            "说话人": "speaker_1",
+            "方言": None,
+            "风格": None,
+            "语速": None,
+            "基频": None,
+            "音量": None,
+            "情感": None,
+            "BGM": {
+                "Genre": None,
+                "Mood": None,
+                "Instrument": None,
+                "Theme": None,
+                "ENV": None,
+                "SNR": None,
+            },
+            "IP": None,
+        }
+    ]
+}
+
+# Per-task recommended decode defaults matching cookbook/test.py values
+TASK_DEFAULTS = {
+    "TTS (Speech)":       {"max_decode_steps": 200, "cfg": 2.0, "sigma": 0.25, "temperature": 0.0},
+    "TTA (Audio Events)": {"max_decode_steps": 200, "cfg": 4.5, "sigma": 0.3,  "temperature": 2.5},
+    "Music (BGM)":        {"max_decode_steps": 400, "cfg": 2.0, "sigma": 0.25, "temperature": 0.0},
+}
+
+
+def resolve_llm_dtype(device):
+    if device.startswith("cuda"):
+        return (
+            torch.bfloat16
+            if torch.cuda.is_bf16_supported(including_emulation=False)
+            else torch.float16
+        )
+    return torch.float32
+
+
+def pick_attention_backend(prefer_flash: bool = True) -> str:
+    if not torch.cuda.is_available():
+        return "eager"
+    if prefer_flash:
+        try:
+            import flash_attn  # noqa: F401
+            return "flash_attention_2"
+        except Exception:
+            pass
+    if hasattr(torch.nn.functional, "scaled_dot_product_attention"):
+        return "sdpa"
+    return "eager"
+
+
+def seed_everything(seed=1895):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+
+
+class MingRuntime:
+    def __init__(self, model_path, device):
+        self.device = device
+        self.llm_dtype = resolve_llm_dtype(device)
+
+        if not os.path.isdir(model_path):
+            local_model_path = snapshot_download(model_path)
+        else:
+            local_model_path = model_path
+
+        config = BailingMMConfig.from_pretrained(local_model_path)
+        config.attn_implementation = "eager"
+        config._attn_implementation = "eager"
+
+        if isinstance(config.llm_config, dict):
+            config.llm_config["attn_implementation"] = "sdpa"
+            config.llm_config["_attn_implementation"] = "sdpa"
+        else:
+            config.llm_config.attn_implementation = "sdpa"
+            config.llm_config._attn_implementation = "sdpa"
+
+        nested_attn_impl = pick_attention_backend(prefer_flash=True)
+        self.nested_attn_impl = nested_attn_impl
+
+        if hasattr(config, "audio_tokenizer_config"):
+            if hasattr(config.audio_tokenizer_config, "enc_kwargs"):
+                if "backbone" in config.audio_tokenizer_config.enc_kwargs:
+                    config.audio_tokenizer_config.enc_kwargs["backbone"]["attn_implementation"] = nested_attn_impl
+                    config.audio_tokenizer_config.enc_kwargs["backbone"]["_attn_implementation"] = nested_attn_impl
+            if hasattr(config.audio_tokenizer_config, "dec_kwargs"):
+                if "backbone" in config.audio_tokenizer_config.dec_kwargs:
+                    config.audio_tokenizer_config.dec_kwargs["backbone"]["attn_implementation"] = nested_attn_impl
+                    config.audio_tokenizer_config.dec_kwargs["backbone"]["_attn_implementation"] = nested_attn_impl
+
+        self.model = BailingMMNativeForConditionalGeneration.from_pretrained(
+            local_model_path,
+            config=config,
+            torch_dtype=self.llm_dtype,
+            low_cpu_mem_usage=True,
+        )
+        self.model = self.model.eval().to(self.llm_dtype).to(device)
+        # Note: on float16 hardware (T4), model.generate() calls self.float()
+        # at the start of each call to upcast everything to float32.
+
+        if self.model.model_type == "dense":
+            self.tokenizer = AutoTokenizer.from_pretrained(local_model_path)
+        else:
+            self.tokenizer = AutoTokenizer.from_pretrained(".", trust_remote_code=True)
+
+        self.model.tokenizer = self.tokenizer
+        self.sample_rate = self.model.config.audio_tokenizer_config.sample_rate
+        self.patch_size = self.model.config.ditar_config["patch_size"]
+        self.model_type = self.model.model_type
+
+        self.spk = SpkembExtractor(f"{local_model_path}/campplus.onnx")
+        self.normalizer = self.init_tn_normalizer()
+
+    def init_tn_normalizer(self, config_file_path=None):
+        if config_file_path is None:
+            config_file_path = "sentence_manager/default_config.yaml"
+        try:
+            with open(config_file_path, "r") as f:
+                config = yaml.safe_load(f)
+        except Exception as e:
+            print(f"Warning: Could not load TN config: {e}")
+            config = {}
+        if "split_token" not in config:
+            config["split_token"] = []
+        assert isinstance(config["split_token"], list)
+        config["split_token"].append(re.escape(self.tokenizer.eos_token))
+        return SentenceNormalizer(config.get("text_norm", {}))
+
+    def create_instruction(self, user_input: dict):
+        new_caption = copy.deepcopy(BASE_CAPTION_TEMPLATE)
+        target_item_dict = new_caption["audio_sequence"][0]
+        for key, value in user_input.items():
+            if key == "BGM" and isinstance(value, dict):
+                target_item_dict["BGM"].update(value)
+            elif key in target_item_dict:
+                target_item_dict[key] = value
+        if target_item_dict["BGM"].get("SNR", None) is not None:
+            new_order = ["序号", "说话人", "BGM", "情感", "方言", "风格", "语速", "基频", "音量", "IP"]
+            target_item_dict = {k: target_item_dict[k] for k in new_order if k in target_item_dict}
+            new_caption["audio_sequence"][0] = target_item_dict
+        return new_caption
+
+    def pad_waveform(self, waveform):
+        pad_align = int(1 / 12.5 * self.patch_size * self.sample_rate)
+        new_len = (waveform.size(-1) + pad_align - 1) // pad_align * pad_align
+        if new_len != waveform.size(1):
+            new_wav = torch.zeros(1, new_len, dtype=waveform.dtype, device=waveform.device)
+            new_wav[:, :waveform.size(1)] = waveform.clone()
+            waveform = new_wav
+        return waveform
+
+    def preprocess_one_prompt_wav(self, waveform_path, use_spk_emb):
+        if not waveform_path:
+            return None, None
+        waveform, sr = torchaudio.load(waveform_path)
+        if waveform.shape[0] > 1:
+            waveform = waveform.mean(0, keepdim=True)
+        if sr != self.sample_rate:
+            waveform = torchaudio.transforms.Resample(orig_freq=sr, new_freq=self.sample_rate)(waveform)
+        waveform1 = waveform.clone()
+        if use_spk_emb:
+            waveform1 = torchaudio.transforms.Resample(orig_freq=self.sample_rate, new_freq=16000)(waveform1)
+            spk_emb = self.spk(waveform1).to(self.device, dtype=torch.float32)
+        else:
+            spk_emb = None
+        return waveform, spk_emb
+
+    def generate_audio(
+        self,
+        task_type,
+        text,
+        ref_audios=None,
+        prompt_text=None,
+        use_tn=False,
+        use_spk_emb=True,
+        use_zero_spk_emb=False,
+        instruction_dict=None,
+        cfg=2.0,
+        sigma=0.25,
+        temperature=0.0,
+        max_decode_steps=200,
+    ):
+        if use_tn:
+            text = self.normalizer.normalize(text)
+
+        if task_type == "TTA (Audio Events)":
+            prompt = "Please generate audio events based on given text.\n"
+        elif task_type == "Music (BGM)":
+            prompt = "Please generate music based on the following description.\n"
+        else:
+            prompt = "Please generate speech based on the following description.\n"
+
+        if not ref_audios:
+            prompt_waveform = None
+            spk_emb = None
+            if use_zero_spk_emb:
+                # float32 is safe on T4; cookbook uses bfloat16 but that requires A100/H100
+                spk_emb = [torch.zeros(1, 192, device=self.device, dtype=torch.float32)]
+        else:
+            paths = ref_audios if isinstance(ref_audios, list) else [ref_audios]
+            processed_prompts = [self.preprocess_one_prompt_wav(p, use_spk_emb) for p in paths if p]
+            waveforms_list = [x[0] for x in processed_prompts if x[0] is not None]
+            spk_embs = [x[1] for x in processed_prompts]
+            prompt_waveform = None
+            if waveforms_list:
+                prompt_waveform = torch.cat(waveforms_list, dim=-1)
+                prompt_waveform = self.pad_waveform(prompt_waveform).to(self.device, dtype=torch.float32)
+            spk_emb = [x for x in spk_embs if x is not None]
+            if not spk_emb:
+                spk_emb = None
+
+        final_instruction = None
+        if instruction_dict:
+            final_instruction = self.create_instruction(instruction_dict)
+            final_instruction = json.dumps(final_instruction, ensure_ascii=False)
+
+        waveform = self.model.generate(
+            prompt=prompt,
+            text=text,
+            spk_emb=spk_emb,
+            instruction=final_instruction,
+            prompt_waveform=prompt_waveform,
+            prompt_text=prompt_text,
+            max_decode_steps=max_decode_steps,
+            cfg=cfg,
+            sigma=sigma,
+            temperature=temperature,
+            use_zero_spk_emb=use_zero_spk_emb,
+        )
+
+        waveform = waveform.float()
+        has_nan = torch.isnan(waveform).any().item()
+        has_inf = torch.isinf(waveform).any().item()
+        print(f"waveform dtype={waveform.dtype} shape={tuple(waveform.shape)} nan={has_nan} inf={has_inf}")
+        if has_nan or has_inf:
+            print("WARNING: NaN/Inf in waveform — replacing with zeros. "
+                  "Verify audio decoder sub-modules were cast to float32.")
+            waveform = torch.nan_to_num(waveform, nan=0.0, posinf=0.0, neginf=0.0)
+        else:
+            print(f"  min={waveform.min().item():.4f}  max={waveform.max().item():.4f}  "
+                  f"abs_mean={waveform.abs().mean().item():.4f}")
+
+        out_path = OUTPUT_DIR / f"{uuid.uuid4().hex}.wav"
+        torchaudio.save(str(out_path), waveform.cpu(), self.sample_rate)
+        return str(out_path)
+
+    def generate_text(self, text, max_decode_steps=200):
+        """
+        Text-only generation via model.generate_text().
+        NOTE: Not supported on MoE models.
+        """
+        prompt = "Please generate speech based on the following description.\n"
+        return self.model.generate_text(
+            prompt=prompt,
+            text=text,
+            max_decode_steps=max_decode_steps,
+        )
+
+
+def load_model(model_path, device):
+    key = f"{model_path}::{device}::{resolve_llm_dtype(device)}"
+    if MODEL_CACHE["model"] and MODEL_CACHE["key"] == key:
+        return runtime_info(MODEL_CACHE["model"])
+    runtime = MingRuntime(model_path, device)
+    MODEL_CACHE["model"] = runtime
+    MODEL_CACHE["key"] = key
+    return runtime_info(runtime)
+
+
+def unload_model():
+    MODEL_CACHE["model"] = None
+    MODEL_CACHE["key"] = None
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return "Model unloaded."
+
+
+def runtime_info(runtime):
+    return json.dumps(
+        {
+            "device": runtime.device,
+            "dtype": str(runtime.llm_dtype),
+            "nested_attention_backend": runtime.nested_attn_impl,
+            "sample_rate": runtime.sample_rate,
+            "model_type": runtime.model_type,
+            "tn_supported": runtime.model_type == "dense",
+            "text_generation_supported": runtime.model_type == "dense",
+        },
+        indent=2,
+    )
+
+
+def update_task_defaults(task_type):
+    """Auto-fill decode sliders with per-task cookbook defaults."""
+    d = TASK_DEFAULTS.get(task_type, TASK_DEFAULTS["TTS (Speech)"])
+    return d["max_decode_steps"], d["cfg"], d["sigma"], d["temperature"]
+
+
+def build_podcast_text(dialog_json_str):
+    """
+    Convert a JSON dialog list into the speaker_N:... format the model expects.
+    e.g. [{"speaker_1":"Hello"},{"speaker_2":"World"}]
+      -> ' speaker_1:Hello\n speaker_2:World\n'
+    """
+    try:
+        dialog = json.loads(dialog_json_str)
+        lines = [f"{k}:{v}" for item in dialog for k, v in item.items()]
+        return " " + "\n ".join(lines) + "\n"
+    except Exception as e:
+        return f"[JSON parse error: {e}]"
+
+
+def generate_audio_wrapper(
+    task_type, text, podcast_mode, podcast_json,
+    ref_audios, prompt_text, use_tn,
+    use_spk_emb, use_zero_spk_emb,
+    ip, emotion, dialect, style, speed, pitch, volume,
+    bgm_genre, bgm_mood, bgm_instrument, bgm_theme, bgm_env, bgm_snr, bgm_duration,
+    cfg, sigma, temperature, max_decode_steps,
+):
+    runtime = MODEL_CACHE["model"]
+    if runtime is None:
+        raise gr.Error("Please load the model first.")
+
+    # Podcast mode: build structured dialog text
+    if task_type == "TTS (Speech)" and podcast_mode:
+        if not podcast_json.strip():
+            raise gr.Error("Podcast mode is enabled but the dialog JSON is empty.")
+        built = build_podcast_text(podcast_json)
+        if built.startswith("[JSON parse error"):
+            raise gr.Error(f"Invalid podcast dialog JSON: {built}")
+        text = built
+
+    # TN check
+    if use_tn and runtime.model_type != "dense":
+        raise gr.Error("Text Normalization is not supported for MoE models.")
+
+    # Build instruction dict
+    instruction = {}
+    if emotion: instruction["情感"] = emotion
+    if dialect: instruction["方言"] = dialect
+    if style:   instruction["风格"] = style
+    if speed:   instruction["语速"] = speed
+    if pitch:   instruction["基频"] = pitch
+    if volume:  instruction["音量"] = volume
+    if ip:      instruction["IP"] = ip
+
+    bgm_dict = {}
+    if bgm_genre:      bgm_dict["Genre"] = bgm_genre
+    if bgm_mood:       bgm_dict["Mood"] = bgm_mood
+    if bgm_instrument: bgm_dict["Instrument"] = bgm_instrument
+    if bgm_theme:      bgm_dict["Theme"] = bgm_theme
+    if bgm_env:        bgm_dict["ENV"] = bgm_env
+    if bgm_snr not in (None, 0, 0.0): bgm_dict["SNR"] = bgm_snr
+    if bgm_dict:
+        instruction["BGM"] = bgm_dict
+    instruction = instruction if instruction else None
+
+    # TTA: clear incompatible inputs
+    if task_type == "TTA (Audio Events)":
+        instruction = None
+        use_spk_emb = False
+        use_zero_spk_emb = False
+        prompt_text = ""
+        ref_audios = None
+
+    # Music: compile BGM attrs into generation text
+    if task_type == "Music (BGM)":
+        music_attrs = []
+        if bgm_genre:      music_attrs.append(f"Genre: {bgm_genre}.")
+        if bgm_mood:       music_attrs.append(f"Mood: {bgm_mood}.")
+        if bgm_instrument: music_attrs.append(f"Instrument: {bgm_instrument}.")
+        if bgm_theme:      music_attrs.append(f"Theme: {bgm_theme}.")
+        if bgm_duration:   music_attrs.append(f"Duration: {bgm_duration}.")
+        if bgm_env:        music_attrs.append(f"ENV: {bgm_env}.")
+        if bgm_snr not in (None, 0, 0.0): music_attrs.append(f"SNR: {bgm_snr}.")
+        if text.strip():   music_attrs.append(f"Text: {text}")
+        text = " " + " ".join(music_attrs)
+
+    # Validation
+    has_music_condition = any([
+        text.strip(), bgm_genre, bgm_mood, bgm_instrument,
+        bgm_theme, bgm_env, bgm_duration, bgm_snr not in (None, 0, 0.0),
+    ])
+    if task_type == "Music (BGM)" and not has_music_condition:
+        raise gr.Error("For Music, provide text or at least one BGM attribute.")
+    elif task_type != "Music (BGM)" and not text.strip():
+        raise gr.Error("Text input cannot be empty.")
+
+    ref_audio_paths = [f.name if hasattr(f, "name") else f for f in ref_audios] if ref_audios else None
+
+    return runtime.generate_audio(
+        task_type=task_type,
+        text=text,
+        ref_audios=ref_audio_paths,
+        prompt_text=prompt_text if prompt_text.strip() else None,
+        use_tn=use_tn,
+        use_spk_emb=use_spk_emb,
+        use_zero_spk_emb=use_zero_spk_emb,
+        instruction_dict=instruction,
+        cfg=cfg,
+        sigma=sigma,
+        temperature=temperature,
+        max_decode_steps=int(max_decode_steps),
+    )
+
+
+def generate_text_wrapper(text, max_decode_steps):
+    runtime = MODEL_CACHE["model"]
+    if runtime is None:
+        raise gr.Error("Please load the model first.")
+    if not text.strip():
+        raise gr.Error("Text input cannot be empty.")
+    if runtime.model_type != "dense":
+        raise gr.Error("Text Generation (generate_text) is only supported on dense models.")
+    return str(runtime.generate_text(text=text, max_decode_steps=int(max_decode_steps)))
+
+
+def build_ui():
+    with gr.Blocks(title="Ming Omni Audio Demo") as demo:
+        gr.Markdown("# Ming Omni Audio Demo")
+        gr.Markdown(
+            "Supported Tasks: **TTS** · **TTA** · **Music/BGM** · **Zero-shot Clone** · "
+            "**Podcast (multi-speaker)** · **Emotion / Dialect / Style / IP / BGM mix** · "
+            "**Text Generation** · **All 3 model variants**"
+        )
+
+        # Model loader 
+        with gr.Row():
+            model_path = gr.Dropdown(
+                choices=MODEL_CHOICES,
+                value=DEFAULT_MODEL,
+                allow_custom_value=True,
+                label="Model (Hub ID or local path)",
+                scale=3,
+                info="Ming-omni-tta-0.5B supports TTA only. MoE 16.8B does not support TN or Text Generation.",
+            )
+            device = gr.Dropdown(["cuda:0"], value="cuda:0", label="Device", scale=1)
+        with gr.Row():
+            load_btn   = gr.Button("Load Model", variant="primary")
+            unload_btn = gr.Button("Unload Model")
+        runtime_box = gr.Code(label="Runtime Info (shows model_type, tn_supported, etc.)", language="json", lines=6)
+
+        # Tabs
+        with gr.Tabs():
+
+            # TAB 1: Audio Generation 
+            with gr.TabItem("Audio Generation"):
+                with gr.Row():
+                    with gr.Column(scale=2):
+
+                        task_type = gr.Radio(
+                            ["TTS (Speech)", "TTA (Audio Events)", "Music (BGM)"],
+                            label="Task Type",
+                            value="TTS (Speech)",
+                        )
+
+                        text = gr.Textbox(
+                            label="Target Text",
+                            placeholder=(
+                                "TTS: plain text\n"
+                                "TTA: describe the sound event (e.g. 'Thunder and a gentle rain')\n"
+                                "Music: describe style/mood, or use BGM fields below\n"
+                                "Podcast: leave blank and use the Podcast Builder accordion"
+                            ),
+                            lines=4,
+                        )
+
+                        use_tn = gr.Checkbox(
+                            label="Enable Text Normalization (TN) — dense models only, not MoE",
+                            value=False,
+                        )
+
+                        # Podcast / Multi-speaker Builder 
+                        with gr.Accordion("🎙️ Podcast / Multi-Speaker Builder", open=False):
+                            gr.Markdown(
+                                "Enable to build a structured multi-speaker dialog. "
+                                "Upload **one reference audio per speaker** "
+                                "(speaker_1 first, speaker_2 second, etc.) in the Reference Audio section. "
+                                "When enabled, the Target Text above is ignored and replaced by the dialog here."
+                            )
+                            podcast_mode = gr.Checkbox(label="Enable Podcast Mode", value=False)
+                            podcast_json = gr.Textbox(
+                                label='Dialog JSON — list of {"speaker_N": "line"} objects',
+                                placeholder=(
+                                    '[\n'
+                                    '  {"speaker_1": "你好，今天天气真好。"},\n'
+                                    '  {"speaker_2": "是啊，适合出去走走。"},\n'
+                                    '  {"speaker_1": "那我们去公园吧！"}\n'
+                                    ']'
+                                ),
+                                lines=7,
+                            )
+                            podcast_preview = gr.Textbox(
+                                label="Compiled text preview (what gets sent to model)",
+                                interactive=False,
+                                lines=3,
+                            )
+                            podcast_json.change(
+                                fn=lambda j: build_podcast_text(j) if j.strip() else "",
+                                inputs=podcast_json,
+                                outputs=podcast_preview,
+                            )
+
+                        # Reference Audio
+                        with gr.Accordion("🎤 Reference Audio (Zero-shot / Podcast)", open=True):
+                            ref_audios = gr.File(
+                                label="Reference Audio(s) — upload multiple for Podcast/multi-speaker",
+                                file_count="multiple",
+                                file_types=["audio"],
+                            )
+                            prompt_text = gr.Textbox(label="Reference Transcript", lines=2)
+                            with gr.Row():
+                                use_spk_emb = gr.Checkbox(
+                                    label="Use Speaker Embedding Extraction",
+                                    value=True,
+                                )
+                                use_zero_spk_emb = gr.Checkbox(
+                                    label="Use Zero Speaker Embedding (for IP / Style)",
+                                    value=False,
+                                )
+
+                        # Voice Attributes
+                        with gr.Accordion("🗣️ Voice Attributes & IP", open=False):
+                            ip      = gr.Textbox(label="IP Name (e.g., 灵小甄)")
+                            emotion = gr.Textbox(label="Emotion (e.g., 高兴)")
+                            dialect = gr.Textbox(label="Dialect (e.g., 广粤话)")
+                            style   = gr.Textbox(label="Style Definition (e.g., ASMR耳语...)")
+                            with gr.Row():
+                                speed  = gr.Textbox(label="Speed (e.g., 快速)",  placeholder="Optional")
+                                pitch  = gr.Textbox(label="Pitch (e.g., 中)",    placeholder="Optional")
+                                volume = gr.Textbox(label="Volume (e.g., 高)",   placeholder="Optional")
+
+                        # BGM 
+                        with gr.Accordion("🎵 BGM & Environmental Sounds", open=False):
+                            gr.Markdown(
+                                "**TTS + BGM mix**: set SNR + traits (requires reference audio).  \n"
+                                "**Music generation**: these fields become the generation prompt.  \n"
+                                "**Speech + Env sound**: set ENV + SNR only."
+                            )
+                            with gr.Row():
+                                bgm_genre      = gr.Textbox(label="Genre (e.g., 当代古典音乐.)")
+                                bgm_mood       = gr.Textbox(label="Mood (e.g., 温暖 / 友善.)")
+                                bgm_instrument = gr.Textbox(label="Instrument (e.g., 电吉他)")
+                            with gr.Row():
+                                bgm_theme = gr.Textbox(label="Theme (e.g., 节日.)")
+                                bgm_env   = gr.Textbox(label="ENV (e.g., Birds chirping)")
+                                bgm_snr   = gr.Number(label="SNR dB (TTS+BGM mix, 0 = off)", value=0.0)
+                            with gr.Row():
+                                bgm_duration = gr.Textbox(label="Duration (e.g., 30s.)", placeholder="Music only")
+
+                        # Decode Settings
+                        with gr.Accordion("⚙️ Decode Settings", open=False):
+                            gr.Markdown(
+                                "Defaults auto-update when Task Type changes to match cookbook values  \n"
+                                "(TTA: cfg=4.5 / temp=2.5 / sigma=0.3 — Music: steps=400)"
+                            )
+                            max_decode_steps = gr.Slider(50, 1000, value=200, step=10,  label="max_decode_steps")
+                            cfg              = gr.Slider(0.0, 10.0, value=2.0, step=0.1,   label="cfg (Guidance Scale)")
+                            sigma            = gr.Slider(0.0, 1.0,  value=0.25, step=0.01, label="sigma")
+                            temperature      = gr.Slider(0.0, 5.0,  value=0.0, step=0.1,   label="temperature")
+
+                        # Auto-update decode sliders on task change
+                        task_type.change(
+                            fn=update_task_defaults,
+                            inputs=task_type,
+                            outputs=[max_decode_steps, cfg, sigma, temperature],
+                        )
+
+                    with gr.Column(scale=1):
+                        generate_btn = gr.Button("▶ Generate Audio", variant="primary", size="lg")
+                        out_audio    = gr.Audio(label="Generated Audio", interactive=False)
+
+                generate_btn.click(
+                    generate_audio_wrapper,
+                    inputs=[
+                        task_type, text, podcast_mode, podcast_json,
+                        ref_audios, prompt_text, use_tn,
+                        use_spk_emb, use_zero_spk_emb,
+                        ip, emotion, dialect, style, speed, pitch, volume,
+                        bgm_genre, bgm_mood, bgm_instrument, bgm_theme, bgm_env, bgm_snr, bgm_duration,
+                        cfg, sigma, temperature, max_decode_steps,
+                    ],
+                    outputs=out_audio,
+                )
+
+            # TAB 2: Text Generation 
+            with gr.TabItem("Text Generation (generate_text)"):
+                gr.Markdown(
+                    "Direct text generation via `model.generate_text()` — "
+                    "equivalent to the **Text Normalization** cookbook cell.  \n"
+                    "**Only supported on dense models** (Ming-omni-tts-0.5B), not MoE (16.8B-A3B)."
+                )
+                with gr.Row():
+                    with gr.Column(scale=2):
+                        tg_text  = gr.Textbox(
+                            label="Input Text",
+                            placeholder="化学反应方程式：\\ce{2H2 + O2 -> 2H2O}",
+                            lines=4,
+                        )
+                        tg_steps = gr.Slider(50, 500, value=200, step=10, label="max_decode_steps")
+                        tg_btn   = gr.Button("▶ Generate Text", variant="primary")
+                    with gr.Column(scale=1):
+                        tg_out = gr.Textbox(label="Model Text Output", lines=6, interactive=False)
+
+                tg_btn.click(
+                    generate_text_wrapper,
+                    inputs=[tg_text, tg_steps],
+                    outputs=tg_out,
+                )
+
+        # ── Model load/unload ──────────────────────────────────────────────────
+        load_btn.click(load_model,    inputs=[model_path, device], outputs=runtime_box)
+        unload_btn.click(unload_model, outputs=runtime_box)
+
+    return demo
+
+
+if __name__ == "__main__":
+    seed_everything()
+    app = build_ui()
+    app.queue()
+    app.launch(server_name="0.0.0.0", server_port=7860, share=True, debug=True)

--- a/gradio_demo.py
+++ b/gradio_demo.py
@@ -85,20 +85,14 @@ def set_attn_backend(config_like, backend: str):
     config_like._attn_implementation = backend
 
 
-def resolve_qwen_attention_backend(device, prefer_flash: bool = True) -> str:
-    if not device.startswith("cuda"):
-        return "eager"
+def resolve_qwen_attention_backend(device) -> str:
     if not torch.cuda.is_bf16_supported(including_emulation=False):
         return "eager"
-    if prefer_flash:
-        try:
-            import flash_attn  # noqa: F401
-            return "flash_attention_2"
-        except Exception:
-            pass
-    if hasattr(torch.nn.functional, "scaled_dot_product_attention"):
+    try:
+        import flash_attn  # noqa: F401
+        return "flash_attention_2"
+    except ImportError:
         return "sdpa"
-    return "eager"
 
 
 def seed_everything(seed=1895):

--- a/gradio_demo.py
+++ b/gradio_demo.py
@@ -117,7 +117,7 @@ class MingRuntime:
         config = BailingMMConfig.from_pretrained(local_model_path)
         set_attn_backend(config, "eager")
 
-        nested_attn_impl = resolve_qwen_attention_backend(device, prefer_flash=True)
+        nested_attn_impl = resolve_qwen_attention_backend(device)
         self.nested_attn_impl = nested_attn_impl
         set_attn_backend(config.llm_config, nested_attn_impl)
 

--- a/gradio_demo.py
+++ b/gradio_demo.py
@@ -74,8 +74,21 @@ def resolve_llm_dtype(device):
     return torch.float32
 
 
-def pick_attention_backend(prefer_flash: bool = True) -> str:
-    if not torch.cuda.is_available():
+def set_attn_backend(config_like, backend: str):
+    if config_like is None:
+        return
+    if isinstance(config_like, dict):
+        config_like["attn_implementation"] = backend
+        config_like["_attn_implementation"] = backend
+        return
+    config_like.attn_implementation = backend
+    config_like._attn_implementation = backend
+
+
+def resolve_qwen_attention_backend(device, prefer_flash: bool = True) -> str:
+    if not device.startswith("cuda"):
+        return "eager"
+    if not torch.cuda.is_bf16_supported(including_emulation=False):
         return "eager"
     if prefer_flash:
         try:
@@ -108,28 +121,19 @@ class MingRuntime:
             local_model_path = model_path
 
         config = BailingMMConfig.from_pretrained(local_model_path)
-        config.attn_implementation = "eager"
-        config._attn_implementation = "eager"
+        set_attn_backend(config, "eager")
 
-        if isinstance(config.llm_config, dict):
-            config.llm_config["attn_implementation"] = "sdpa"
-            config.llm_config["_attn_implementation"] = "sdpa"
-        else:
-            config.llm_config.attn_implementation = "sdpa"
-            config.llm_config._attn_implementation = "sdpa"
-
-        nested_attn_impl = pick_attention_backend(prefer_flash=True)
+        nested_attn_impl = resolve_qwen_attention_backend(device, prefer_flash=True)
         self.nested_attn_impl = nested_attn_impl
+        set_attn_backend(config.llm_config, nested_attn_impl)
 
         if hasattr(config, "audio_tokenizer_config"):
             if hasattr(config.audio_tokenizer_config, "enc_kwargs"):
                 if "backbone" in config.audio_tokenizer_config.enc_kwargs:
-                    config.audio_tokenizer_config.enc_kwargs["backbone"]["attn_implementation"] = nested_attn_impl
-                    config.audio_tokenizer_config.enc_kwargs["backbone"]["_attn_implementation"] = nested_attn_impl
+                    set_attn_backend(config.audio_tokenizer_config.enc_kwargs["backbone"], nested_attn_impl)
             if hasattr(config.audio_tokenizer_config, "dec_kwargs"):
                 if "backbone" in config.audio_tokenizer_config.dec_kwargs:
-                    config.audio_tokenizer_config.dec_kwargs["backbone"]["attn_implementation"] = nested_attn_impl
-                    config.audio_tokenizer_config.dec_kwargs["backbone"]["_attn_implementation"] = nested_attn_impl
+                    set_attn_backend(config.audio_tokenizer_config.dec_kwargs["backbone"], nested_attn_impl)
 
         self.model = BailingMMNativeForConditionalGeneration.from_pretrained(
             local_model_path,

--- a/gradio_demo.py
+++ b/gradio_demo.py
@@ -69,7 +69,7 @@ def resolve_llm_dtype(device):
         return (
             torch.bfloat16
             if torch.cuda.is_bf16_supported(including_emulation=False)
-            else torch.float16
+            else torch.float32
         )
     return torch.float32
 
@@ -138,8 +138,7 @@ class MingRuntime:
             low_cpu_mem_usage=True,
         )
         self.model = self.model.eval().to(self.llm_dtype).to(device)
-        # Note: on float16 hardware (T4), model.generate() calls self.float()
-        # at the start of each call to upcast everything to float32.
+        # Non-bf16 CUDA GPUs such as T4 run directly in float32.
 
         if self.model.model_type == "dense":
             self.tokenizer = AutoTokenizer.from_pretrained(local_model_path)

--- a/modeling_bailingmm.py
+++ b/modeling_bailingmm.py
@@ -58,9 +58,8 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
         return next(self.model.parameters()).dtype
 
     def _autocast_context(self):
-        enabled = self.device.type == 'cuda' and self._infer_dtype in (torch.float16, torch.bfloat16)
-        dtype = self._infer_dtype if enabled else torch.bfloat16
-        return torch.autocast(device_type=self.device.type, dtype=dtype, enabled=enabled)
+        enabled = self.device.type == 'cuda' and self._infer_dtype == torch.bfloat16
+        return torch.autocast(device_type=self.device.type, dtype=torch.bfloat16, enabled=enabled)
 
     def get_rope_index(
         self,

--- a/modeling_bailingmm.py
+++ b/modeling_bailingmm.py
@@ -439,10 +439,6 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
         temperature=0,
         use_zero_spk_emb=False
     ):
-        if self._infer_dtype == torch.float16:
-            logger.info("[dtype] T4: upcasting model to float32 for this call")
-            self.float()
-
         stream_state = (None, None, None)
         past_key_values = None
         use_cache = True

--- a/modeling_bailingmm.py
+++ b/modeling_bailingmm.py
@@ -167,12 +167,14 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
         return position_ids, mrope_position_deltas
 
     def prepare_inputs_for_generation(self):
+        # An empty function to be compatible with the PEFT library for LoRA training. This function is not used in practice.
         pass
 
-    def prepare_input_embed(self, prompt, text, spk_emb=None, instruction=None,prompt_latent=None, prompt_text=None, use_zero_spk_emb=False):
+    def prepare_input_embed(self, prompt, text, spk_emb=None, instruction=None, prompt_latent=None, prompt_text=None, use_zero_spk_emb=False):
         """
         Prepares the input embeddings for the model by constructing a complex sequence of text tokens and injecting continuous features like speaker embeddings and audio latents.
         """
+        # Process Speaker Embeddings (if provided)
         spk_emb_prompt = []
         if spk_emb is not None:
             for i, se in enumerate(spk_emb):
@@ -195,6 +197,7 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                         self.tokenizer.encode("</spk>\n")
                     )
 
+        # Process Instruction Control (if provided)
         instruction_prompt = []
         if instruction is not None:
             instruction_prompt = (
@@ -202,6 +205,7 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 self.tokenizer.encode('<|endoftext|>')
             )
 
+        # Process Zero-Shot Specch Prompt (if provided)
         prompt_text_token = []
         prompt_latent_token = []
         if prompt_latent is not None and prompt_text is not None:
@@ -209,19 +213,24 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
             prompt_latent = prompt_latent.reshape(-1, self.patch_size, self.latent_dim)
             prompt_latent = self.linear_proj_audio(prompt_latent)
             prompt_latent = prompt_latent.reshape(bsz, -1, prompt_latent.size(-1))
+
             prompt_text_token = self.tokenizer.encode(prompt_text)
             prompt_latent_token = [self.tokenizer.convert_tokens_to_ids('<audioPatch>')] * prompt_latent.size(1)
 
+        # Special handling for BGM prompts: remove the 'Text input:' prefix as it's not needed.
         prompt2 = self.tokenizer.encode(' Text input:\n')
         if 'Genre: ' in text and 'Mood: ' in text and 'Instrument: ' in text and 'Theme: ' in text and 'Duration: ' in text:
             prompt2 = []
 
+        # Assemble all the processed parts into the final input token sequence based on the model type.
         if self.model_type == 'dense':
             input_part = (
                 self.tokenizer.encode("<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n") +
                 self.tokenizer.encode("<|im_start|>user\n") +
                 self.tokenizer.encode(prompt) +
-                spk_emb_prompt + prompt2 + prompt_text_token +
+                spk_emb_prompt +
+                prompt2 +
+                prompt_text_token +
                 self.tokenizer.encode(text) +
                 self.tokenizer.encode("<|im_end|>\n") +
                 self.tokenizer.encode("<|im_start|>assistant\n") +
@@ -230,10 +239,13 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 prompt_latent_token
             )
         else:
+            # MoE model
             input_part = (
                 self.tokenizer.encode("<role>HUMAN</role>") +
                 self.tokenizer.encode(prompt) +
-                spk_emb_prompt + prompt2 + prompt_text_token +
+                spk_emb_prompt +
+                prompt2 +
+                prompt_text_token +
                 self.tokenizer.encode(text) +
                 self.tokenizer.encode("<role>ASSISTANT</role>") +
                 instruction_prompt +
@@ -244,15 +256,18 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
         input_ids = torch.tensor(input_part, dtype=torch.long).unsqueeze(0).to(self.device)
         inputs_embeds = self.model.get_input_embeddings()(input_ids).to(self.device)
 
+        # Inject speaker embeddings.
         if spk_emb is not None:
-            spk_token_id = self.tokenizer.convert_tokens_to_ids(
-                "<|vision_start|>" if self.model_type == 'dense' else "<spk>"
-            )
+            if self.model_type == 'dense':
+                spk_token_id = self.tokenizer.convert_tokens_to_ids("<|vision_start|>")
+            else:
+                spk_token_id = self.tokenizer.convert_tokens_to_ids("<spk>")
             spk_indices = torch.where(input_ids[0] == spk_token_id)[0]
             assert len(spk_indices) > 0
             for i, se in enumerate(spk_emb):
                 inputs_embeds[0, spk_indices[i] + 1] = se
 
+        # NOTE: This implementation currently assumes a batch size of 1.
         if prompt_latent is not None:
             audio_token_id = self.tokenizer.convert_tokens_to_ids("<audio>")
             audio_indices = torch.where(input_ids[0] == audio_token_id)[0]
@@ -262,45 +277,71 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
 
         return input_ids, inputs_embeds
 
-    def sample_text(self, prompt, text, max_decode_steps=200):
-        assert self.model_type == 'dense', "Not supported for MoE model"
-        input_ids, inputs_embeds = self.prepare_input_embed(prompt=prompt, text=text)
-        input_ids, inputs_embeds = input_ids[:, :-1], inputs_embeds[:, :-1, ...]
+    def sample_text(
+        self,
+        prompt,
+        text,
+        max_decode_steps=200,
+    ):
+        assert self.model_type == 'dense', "This functionality currently is not supported for MoE model"
+        input_ids, inputs_embeds = self.prepare_input_embed(
+            prompt=prompt,
+            text=text,
+        )
+        input_ids, inputs_embeds = input_ids[:,:-1], inputs_embeds[:,:-1,...]
         logger.info(self.tokenizer.decode(input_ids[0].cpu().numpy().tolist()).__repr__())
         attention_mask = torch.ones(input_ids.shape).to(input_ids.device)
+        position_ids = (attention_mask.cumsum(-1) - 1).masked_fill_((attention_mask == 0), 1)
         self.rope_deltas = None
+        past_key_values = None
+
         generated_ids = self.model.generate(
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
             max_new_tokens=200,
             eos_token_id=self.tokenizer.encode("<text_eos>")
         )
+
         stop_id = self.tokenizer.encode("<text_eos>")
         stop_index = [i for i, token in enumerate(generated_ids[0].tolist()) if token == stop_id[0]]
         generated_ids = generated_ids[:, 1:stop_index[0]]
         response = self.tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
         yield response, True
 
-    def sample(self, prompt, text, spk_emb=None, instruction=None,
-               prompt_waveform=None, prompt_text=None, max_decode_steps=200,
-               cfg=2.0, sigma=0.25, temperature=0, use_zero_spk_emb=False):
-
+    def sample(
+        self,
+        prompt,
+        text,
+        spk_emb=None,
+        instruction=None,
+        prompt_waveform=None,
+        prompt_text=None,
+        max_decode_steps=200,
+        cfg=2.0,
+        sigma=0.25,
+        temperature=0,
+        use_zero_spk_emb=False
+    ):
+        # Prepare inputs
         if prompt_waveform is not None and prompt_text is not None:
             prompt_waveform_length = torch.tensor([prompt_waveform.size(1)], dtype=torch.long, device=self.device)
-            prompt_latent, prompt_latent_length = self.audio.encode_latent(
-                prompt_waveform.to(self.device), prompt_waveform_length
-            )
+            prompt_latent, prompt_latent_length = self.audio.encode_latent(prompt_waveform.to(self.device), prompt_waveform_length)
         else:
             prompt_latent, prompt_latent_length = None, None
 
         input_ids, inputs_embeds = self.prepare_input_embed(
-            prompt=prompt, text=text, spk_emb=spk_emb, instruction=instruction,
-            prompt_latent=prompt_latent, prompt_text=prompt_text,
+            prompt=prompt,
+            text=text,
+            spk_emb=spk_emb,
+            instruction=instruction,
+            prompt_latent=prompt_latent,
+            prompt_text=prompt_text,
             use_zero_spk_emb=use_zero_spk_emb
         )
         logger.info(self.tokenizer.decode(input_ids[0].cpu().numpy().tolist()).__repr__())
         attention_mask = torch.ones(input_ids.shape).to(input_ids.device)
 
+        # Obtain position_ids
         if self.model_type == 'dense':
             position_ids = (attention_mask.cumsum(-1) - 1).masked_fill_((attention_mask == 0), 1)
         else:
@@ -317,7 +358,7 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
 
         past_key_values = None
         result = []
-
+        # Each inference step combines Autoregressive (AR) decoding with Flow Matching
         for step in tqdm(range(max_decode_steps)):
             with self._autocast_context():
                 outputs = self.model(
@@ -331,10 +372,10 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                     use_cache=True,
                     past_key_values=past_key_values
                 )
-
             past_key_values = outputs.past_key_values
             z_diff = outputs.hidden_states[-1][:, -1:, :]
 
+            # Initialize the latent_history for the first step
             if step == 0:
                 latent_history = torch.zeros(
                     1, self.history_patch_size, self.latent_dim,
@@ -347,12 +388,14 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                     else:
                         latent_history[:, start_index:, :] = prompt_latent
 
+            # Predict the latent for the current timestep using the Flow Matching head, conditioned on the history and other inputs.
             sampled_token_latent, trajectory = self.flowloss.sample(
                 z_diff, latent_history, cfg, self.patch_size,
                 sigma=sigma, temperature=temperature
             )
             result.append(sampled_token_latent)
 
+            # Check if the generation is complete.
             if self.stop_head(z_diff)[0][0].softmax(dim=-1)[1] > 0.5 and step > 3:
                 yield sampled_token_latent, True
                 break
@@ -361,6 +404,7 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
 
             inputs_embeds = self.linear_proj_audio(sampled_token_latent)
 
+            # Update position_ids, attention_mask, latent_history for next step
             if self.model_type == 'dense':
                 position_ids = position_ids[:, -1:] + 1
             else:
@@ -381,9 +425,20 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
             latent_history[:, -self.patch_size:, :] = sampled_token_latent
 
     @torch.inference_mode()
-    def generate(self, prompt, text, spk_emb=None, instruction=None,
-                 prompt_waveform=None, prompt_text=None, max_decode_steps=200,
-                 cfg=2.0, sigma=0.25, temperature=0, use_zero_spk_emb=False):
+    def generate(
+        self,
+        prompt,
+        text,
+        spk_emb=None,
+        instruction=None,
+        prompt_waveform=None,
+        prompt_text=None,
+        max_decode_steps=200,
+        cfg=2.0,
+        sigma=0.25,
+        temperature=0,
+        use_zero_spk_emb=False
+    ):
         if self._infer_dtype == torch.float16:
             logger.info("[dtype] T4: upcasting model to float32 for this call")
             self.float()
@@ -393,7 +448,6 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
         use_cache = True
         speech = []
         sampled_tokens_list = []
-
         with self._autocast_context():
             for sampled_tokens, last_chunk in self.sample(
                     prompt=prompt,
@@ -416,10 +470,21 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 # sampled_tokens_list.append(sampled_tokens)
 
         speech = torch.cat(speech, dim=-1)
+
+        # # For non-streaming decode
+        # sampled_tokens = torch.cat(sampled_tokens_list, dim=1)
+        # with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
+        #     speech = self.audio.decode(sampled_tokens, past_key_values=None, use_cache=False)[0]
+
         return speech.cpu().float()[0]
 
     @torch.inference_mode()
-    def generate_text(self, prompt, text, max_decode_steps=200):
+    def generate_text(
+        self,
+        prompt,
+        text,
+        max_decode_steps=200,
+    ):
         sampled_texts_list = []
         with self._autocast_context():
             for sampled_tokens, last_chunk in self.sample_text(

--- a/modeling_bailingmm.py
+++ b/modeling_bailingmm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # coding=utf-8
 # Copyright (c) Ant Group. All rights reserved.
-
 import torch
 import torch.nn as nn
 from tqdm import tqdm
@@ -12,7 +11,6 @@ from fm.dit import Aggregator
 from fm.flowloss import FlowLoss
 from modeling_bailing_moe import BailingMoeForCausalLM
 from audio_tokenizer.modeling_audio_vae import AudioVAE
-
 
 _CONFIG_FOR_DOC = "BailingMMConfig"
 
@@ -25,34 +23,25 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
     _supports_flash_attn_2 = True
     _tied_weights_keys = ["model.lm_head.weight"]
 
-    def __init__(
-        self,
-        config: BailingMMConfig,
-    ):
+    def __init__(self, config: BailingMMConfig):
         super().__init__(config)
         self.config: BailingMMConfig = config
-
-        self.llm_dytpe = torch.bfloat16
         self.model_type = config.model_type
 
-        # Dense Model: Utilizes the Qwen2.5-0.5B model.
-        # MoE Model: Utilizes the Bailing-MoE-Lite-16.8B model.
+        # Dense Model: Qwen2.5-0.5B. MoE Model: Bailing-MoE-Lite-16.8B.
         if self.model_type == 'dense':
-            config = Qwen2Config.from_dict(self.config.llm_config)
-            self.model = Qwen2ForCausalLM(config)
+            llm_config = Qwen2Config.from_dict(self.config.llm_config)
+            self.model = Qwen2ForCausalLM(llm_config)
         else:
             self.model = BailingMoeForCausalLM(self.config.llm_config)
 
-        # Audio tokenizer
         self.audio = AudioVAE(self.config.audio_tokenizer_config)
-
         self.latent_dim = self.config.audio_tokenizer_config.enc_kwargs['latent_dim']
         self.linear_proj_audio = Aggregator(
             in_channels=self.latent_dim,
             llm_input_dim=self.model.config.hidden_size,
             **self.config.aggregator_config,
         )
-
         self.patch_size = self.config.ditar_config['patch_size']
         self.history_patch_size = self.config.ditar_config.get('history_patch_size', self.patch_size)
         self.flowloss = FlowLoss(
@@ -63,6 +52,28 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
         self.stop_head = nn.Linear(self.model.config.hidden_size, 2, bias=True)
         self.spk_head = nn.Linear(192, self.model.config.hidden_size, bias=True)
         self.post_init()
+
+    # dtype strategy 
+    # 1. BFLOAT16 (A100/H100/L4): Fast path. 8-bit exponent matches FP32;
+    #    ISTFT complex math and ODE solvers are numerically safe here.
+    # 
+    # 2. FLOAT16 (T4/Legacy): 5-bit exponent (max ~65k) is a death trap for 
+    #    audio spectrograms and ODE trajectories. Results in ComplexHalf NaN.
+    #
+    # 3. WHY FULL FP32 ON T4? 
+    #    - Transformers `from_pretrained` overwrites granular `module.float()` 
+    #      calls in-place post-init. 
+    #    - Buffer mismatches (e.g. Hann window) trigger NaNs even if weights 
+    #      are FP32.
+    #    - Memory Trade-off: 0.5B LLM adds ~1GB overhead.
+    #
+    #   generate() detects fp16 and casts the whole model to fp32 once per
+    #   call via self.float(). autocast is skipped on the fp16 path.
+
+    @property
+    def _infer_dtype(self) -> torch.dtype:
+        """Read actual dtype from LLM backbone params — truth after from_pretrained."""
+        return next(self.model.parameters()).dtype
 
     def get_rope_index(
         self,
@@ -80,18 +91,14 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
         inputs_embeds=None
     ):
         use_abs_time_pos = second_per_grid_ts is not None
-
         mrope_position_deltas = []
         if image_grid_thw is not None or video_grid_thw is not None:
             total_input_ids = input_ids
             if attention_mask is None:
                 attention_mask = torch.ones_like(total_input_ids)
             position_ids = torch.ones(
-                3,
-                input_ids.shape[0],
-                input_ids.shape[1],
-                dtype=input_ids.dtype,
-                device=input_ids.device,
+                3, input_ids.shape[0], input_ids.shape[1],
+                dtype=input_ids.dtype, device=input_ids.device,
             )
             image_index, video_index = 0, 0
             attention_mask = attention_mask.to(total_input_ids.device)
@@ -99,18 +106,13 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 input_ids = input_ids[attention_mask[i] == 1]
                 image_nums, video_nums = 0, 0
                 if image_grid_thw is not None:
-                    vision_start_indices = torch.argwhere(
-                        input_ids == image_start_token_id
-                    ).squeeze(1)
+                    vision_start_indices = torch.argwhere(input_ids == image_start_token_id).squeeze(1)
                     vision_tokens = input_ids[vision_start_indices + 1]
                     image_nums = (vision_tokens == image_token_id).sum()
                 if video_grid_thw is not None:
-                    vision_start_indices = torch.argwhere(
-                        input_ids == video_start_token_id
-                    ).squeeze(1)
+                    vision_start_indices = torch.argwhere(input_ids == video_start_token_id).squeeze(1)
                     vision_tokens = input_ids[vision_start_indices + 1]
                     video_nums = (vision_tokens == video_token_id).sum()
-
                 input_tokens = input_ids.tolist()
                 llm_pos_ids_list: list = []
                 st = 0
@@ -125,86 +127,47 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                     else:
                         ed_video = len(input_tokens) + 1
                     if ed_image < ed_video:
-                        t, h, w = (
-                            image_grid_thw[image_index][0],
-                            image_grid_thw[image_index][1],
-                            image_grid_thw[image_index][2],
-                        )
+                        t, h, w = image_grid_thw[image_index][0], image_grid_thw[image_index][1], image_grid_thw[image_index][2]
                         second_per_grid_t = 0
                         image_index += 1
                         remain_images -= 1
                         ed = ed_image
-
                     else:
-                        t, h, w = (
-                            video_grid_thw[video_index][0],
-                            video_grid_thw[video_index][1],
-                            video_grid_thw[video_index][2],
-                        )
-                        if second_per_grid_ts is not None:
-                            second_per_grid_t = second_per_grid_ts[video_index]
-                        else:
-                            second_per_grid_t = 1.0
+                        t, h, w = video_grid_thw[video_index][0], video_grid_thw[video_index][1], video_grid_thw[video_index][2]
+                        second_per_grid_t = second_per_grid_ts[video_index] if second_per_grid_ts is not None else 1.0
                         video_index += 1
                         remain_videos -= 1
                         ed = ed_video
-                    llm_grid_t, llm_grid_h, llm_grid_w = (
-                        t.item(),
-                        h.item() // spatial_merge_size,
-                        w.item() // spatial_merge_size,
-                    )
+                    llm_grid_t = t.item()
+                    llm_grid_h = h.item() // spatial_merge_size
+                    llm_grid_w = w.item() // spatial_merge_size
                     text_len = ed - st
-
                     st_idx = llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
-                    llm_pos_ids_list.append(
-                        torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
-                    )
-
+                    llm_pos_ids_list.append(torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx)
                     range_tensor = torch.arange(llm_grid_t).view(-1, 1)
                     expanded_range = range_tensor.expand(-1, llm_grid_h * llm_grid_w)
                     if use_abs_time_pos:
-                        time_tensor = expanded_range * second_per_grid_t * tokens_per_second
-                        time_tensor_long = time_tensor.long()
+                        time_tensor_long = (expanded_range * second_per_grid_t * tokens_per_second).long()
                     else:
                         time_tensor_long = expanded_range.long()
                     t_index = time_tensor_long.flatten()
-
-                    h_index = (
-                        torch.arange(llm_grid_h)
-                        .view(1, -1, 1)
-                        .expand(llm_grid_t, -1, llm_grid_w)
-                        .flatten()
-                    )
-                    w_index = (
-                        torch.arange(llm_grid_w)
-                        .view(1, 1, -1)
-                        .expand(llm_grid_t, llm_grid_h, -1)
-                        .flatten()
-                    )
-                    llm_pos_ids_list.append(
-                        torch.stack([t_index, h_index, w_index]) + text_len + st_idx
-                    )
+                    h_index = torch.arange(llm_grid_h).view(1, -1, 1).expand(llm_grid_t, -1, llm_grid_w).flatten()
+                    w_index = torch.arange(llm_grid_w).view(1, 1, -1).expand(llm_grid_t, llm_grid_h, -1).flatten()
+                    llm_pos_ids_list.append(torch.stack([t_index, h_index, w_index]) + text_len + st_idx)
                     st = ed + llm_grid_t * llm_grid_h * llm_grid_w
-
                 if st < len(input_tokens):
                     st_idx = llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
                     text_len = len(input_tokens) - st
-                    llm_pos_ids_list.append(
-                        torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
-                    )
-
+                    llm_pos_ids_list.append(torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx)
                 llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
                 position_ids[..., i, attention_mask[i] == 1] = llm_positions.to(position_ids.device)
                 mrope_position_deltas.append(llm_positions.max() + 1 - len(total_input_ids[i]))
-            mrope_position_deltas = torch.tensor(
-                mrope_position_deltas, device=input_ids.device
-            ).unsqueeze(1)
+            mrope_position_deltas = torch.tensor(mrope_position_deltas, device=input_ids.device).unsqueeze(1)
         else:
             device = inputs_embeds.device if inputs_embeds is not None else input_ids.device
             length = inputs_embeds.size(1) if inputs_embeds is not None else input_ids.size(1)
             bsz = inputs_embeds.size(0) if inputs_embeds is not None else input_ids.size(0)
             dtype = inputs_embeds.dtype if inputs_embeds is not None else input_ids.dtype
-
             if attention_mask is not None:
                 position_ids = attention_mask.long().cumsum(-1) - 1
                 position_ids.masked_fill_(attention_mask == 0, 1)
@@ -212,28 +175,15 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 max_position_ids = position_ids.max(0, keepdim=False)[0].max(-1, keepdim=True)[0]
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
-                position_ids = (
-                    torch.arange(length, device=device)
-                    .view(1, 1, -1)
-                    .expand(3, bsz, -1)
-                )
-                mrope_position_deltas = torch.zeros(
-                    [bsz, 1],
-                    device=device,
-                    dtype=dtype,
-                )
-
+                position_ids = torch.arange(length, device=device).view(1, 1, -1).expand(3, bsz, -1)
+                mrope_position_deltas = torch.zeros([bsz, 1], device=device, dtype=dtype)
         return position_ids, mrope_position_deltas
 
     def prepare_inputs_for_generation(self):
-        # An empty function to be compatible with the PEFT library for LoRA training. This function is not used in practice.
         pass
 
-    def prepare_input_embed(self, prompt, text, spk_emb=None, instruction=None, prompt_latent=None, prompt_text=None, use_zero_spk_emb=False):
-        """
-        Prepares the input embeddings for the model by constructing a complex sequence of text tokens and injecting continuous features like speaker embeddings and audio latents.
-        """
-        # Process Speaker Embeddings (if provided)
+    def prepare_input_embed(self, prompt, text, spk_emb=None, instruction=None,
+                            prompt_latent=None, prompt_text=None, use_zero_spk_emb=False):
         spk_emb_prompt = []
         if spk_emb is not None:
             for i, se in enumerate(spk_emb):
@@ -255,7 +205,7 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                         self.tokenizer.encode("<audioPatch>") +
                         self.tokenizer.encode("</spk>\n")
                     )
-        # Process Instruction Control (if provided)
+
         instruction_prompt = []
         if instruction is not None:
             instruction_prompt = (
@@ -263,7 +213,6 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 self.tokenizer.encode('<|endoftext|>')
             )
 
-        # Process Zero-Shot Specch Prompt (if provided)
         prompt_text_token = []
         prompt_latent_token = []
         if prompt_latent is not None and prompt_text is not None:
@@ -271,24 +220,19 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
             prompt_latent = prompt_latent.reshape(-1, self.patch_size, self.latent_dim)
             prompt_latent = self.linear_proj_audio(prompt_latent)
             prompt_latent = prompt_latent.reshape(bsz, -1, prompt_latent.size(-1))
-
             prompt_text_token = self.tokenizer.encode(prompt_text)
             prompt_latent_token = [self.tokenizer.convert_tokens_to_ids('<audioPatch>')] * prompt_latent.size(1)
 
-        # Special handling for BGM prompts: remove the 'Text input:' prefix as it's not needed.
         prompt2 = self.tokenizer.encode(' Text input:\n')
         if 'Genre: ' in text and 'Mood: ' in text and 'Instrument: ' in text and 'Theme: ' in text and 'Duration: ' in text:
             prompt2 = []
 
-        # Assemble all the processed parts into the final input token sequence based on the model type.
         if self.model_type == 'dense':
             input_part = (
                 self.tokenizer.encode("<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n") +
                 self.tokenizer.encode("<|im_start|>user\n") +
                 self.tokenizer.encode(prompt) +
-                spk_emb_prompt +
-                prompt2 +
-                prompt_text_token +
+                spk_emb_prompt + prompt2 + prompt_text_token +
                 self.tokenizer.encode(text) +
                 self.tokenizer.encode("<|im_end|>\n") +
                 self.tokenizer.encode("<|im_start|>assistant\n") +
@@ -297,13 +241,10 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 prompt_latent_token
             )
         else:
-            # MoE model
             input_part = (
                 self.tokenizer.encode("<role>HUMAN</role>") +
                 self.tokenizer.encode(prompt) +
-                spk_emb_prompt +
-                prompt2 +
-                prompt_text_token +
+                spk_emb_prompt + prompt2 + prompt_text_token +
                 self.tokenizer.encode(text) +
                 self.tokenizer.encode("<role>ASSISTANT</role>") +
                 instruction_prompt +
@@ -313,93 +254,63 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
 
         input_ids = torch.tensor(input_part, dtype=torch.long).unsqueeze(0).to(self.device)
         inputs_embeds = self.model.get_input_embeddings()(input_ids).to(self.device)
-        
-        # Inject speaker embeddings.
+
         if spk_emb is not None:
-            if self.model_type == 'dense':
-                spk_token_id = self.tokenizer.convert_tokens_to_ids("<|vision_start|>")
-            else:
-                spk_token_id = self.tokenizer.convert_tokens_to_ids("<spk>")
+            spk_token_id = self.tokenizer.convert_tokens_to_ids(
+                "<|vision_start|>" if self.model_type == 'dense' else "<spk>"
+            )
             spk_indices = torch.where(input_ids[0] == spk_token_id)[0]
             assert len(spk_indices) > 0
             for i, se in enumerate(spk_emb):
                 inputs_embeds[0, spk_indices[i] + 1] = se
-        
-        # NOTE: This implementation currently assumes a batch size of 1.
+
         if prompt_latent is not None:
             audio_token_id = self.tokenizer.convert_tokens_to_ids("<audio>")
             audio_indices = torch.where(input_ids[0] == audio_token_id)[0]
             assert len(audio_indices) > 0
-            # 只考虑batchsize=1
             inputs_embeds[0, audio_indices[0] + 1:audio_indices[0] + 1 + prompt_latent.size(1), :] = prompt_latent[0]
 
         return input_ids, inputs_embeds
 
-    def sample_text(
-        self,
-        prompt,
-        text,
-        max_decode_steps=200,
-    ):
-        assert self.model_type == 'dense', "This functionality currently is not supported for MoE model"
-        input_ids, inputs_embeds = self.prepare_input_embed(
-            prompt=prompt,
-            text=text,
-        )
-        input_ids, inputs_embeds = input_ids[:,:-1], inputs_embeds[:,:-1,...]
+    def sample_text(self, prompt, text, max_decode_steps=200):
+        assert self.model_type == 'dense', "Not supported for MoE model"
+        input_ids, inputs_embeds = self.prepare_input_embed(prompt=prompt, text=text)
+        input_ids, inputs_embeds = input_ids[:, :-1], inputs_embeds[:, :-1, ...]
         logger.info(self.tokenizer.decode(input_ids[0].cpu().numpy().tolist()).__repr__())
         attention_mask = torch.ones(input_ids.shape).to(input_ids.device)
-        position_ids = (attention_mask.cumsum(-1) - 1).masked_fill_((attention_mask == 0), 1)
         self.rope_deltas = None
-        past_key_values = None
-
         generated_ids = self.model.generate(
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
             max_new_tokens=200,
             eos_token_id=self.tokenizer.encode("<text_eos>")
         )
-
         stop_id = self.tokenizer.encode("<text_eos>")
         stop_index = [i for i, token in enumerate(generated_ids[0].tolist()) if token == stop_id[0]]
         generated_ids = generated_ids[:, 1:stop_index[0]]
         response = self.tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
         yield response, True
 
-    def sample(
-        self,
-        prompt,
-        text,
-        spk_emb=None,
-        instruction=None,
-        prompt_waveform=None,
-        prompt_text=None,
-        max_decode_steps=200,
-        cfg=2.0,
-        sigma=0.25,
-        temperature=0,
-        use_zero_spk_emb=False
-    ):
-        # Prepare inputs
+    def sample(self, prompt, text, spk_emb=None, instruction=None,
+               prompt_waveform=None, prompt_text=None, max_decode_steps=200,
+               cfg=2.0, sigma=0.25, temperature=0, use_zero_spk_emb=False):
+
         if prompt_waveform is not None and prompt_text is not None:
             prompt_waveform_length = torch.tensor([prompt_waveform.size(1)], dtype=torch.long, device=self.device)
-            prompt_latent, prompt_latent_length = self.audio.encode_latent(prompt_waveform.to(self.device), prompt_waveform_length)
+            prompt_latent, prompt_latent_length = self.audio.encode_latent(
+                prompt_waveform.to(self.device), prompt_waveform_length
+            )
         else:
             prompt_latent, prompt_latent_length = None, None
 
         input_ids, inputs_embeds = self.prepare_input_embed(
-            prompt=prompt,
-            text=text,
-            spk_emb=spk_emb,
-            instruction=instruction,
-            prompt_latent=prompt_latent,
-            prompt_text=prompt_text,
+            prompt=prompt, text=text, spk_emb=spk_emb, instruction=instruction,
+            prompt_latent=prompt_latent, prompt_text=prompt_text,
             use_zero_spk_emb=use_zero_spk_emb
         )
         logger.info(self.tokenizer.decode(input_ids[0].cpu().numpy().tolist()).__repr__())
         attention_mask = torch.ones(input_ids.shape).to(input_ids.device)
 
-        # Obtain position_ids
         if self.model_type == 'dense':
             position_ids = (attention_mask.cumsum(-1) - 1).masked_fill_((attention_mask == 0), 1)
         else:
@@ -409,17 +320,18 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 video_token_id=self.config.llm_config.image_patch_token,
                 image_start_token_id=self.config.llm_config.image_start_token,
                 video_start_token_id=self.config.llm_config.video_start_token,
-                image_grid_thw=None,
-                video_grid_thw=None,
+                image_grid_thw=None, video_grid_thw=None,
                 attention_mask=attention_mask,
             )
             self.rope_deltas = rope_deltas
 
+        # Use actual dtype from params (post from_pretrained)
+        run_dtype = self._infer_dtype
         past_key_values = None
         result = []
-        # Each inference step combines Autoregressive (AR) decoding with Flow Matching
+
         for step in tqdm(range(max_decode_steps)):
-            with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
+            with torch.autocast(device_type='cuda', dtype=run_dtype):
                 outputs = self.model(
                     attention_mask=attention_mask,
                     position_ids=position_ids,
@@ -431,24 +343,28 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                     use_cache=True,
                     past_key_values=past_key_values
                 )
+
             past_key_values = outputs.past_key_values
             z_diff = outputs.hidden_states[-1][:, -1:, :]
 
-            # Initialize the latent_history for the first step
             if step == 0:
-                latent_history = torch.zeros(1, self.history_patch_size, self.latent_dim).to(z_diff.device)
+                latent_history = torch.zeros(
+                    1, self.history_patch_size, self.latent_dim,
+                    dtype=z_diff.dtype, device=z_diff.device
+                )
                 if prompt_latent is not None:
                     start_index = self.history_patch_size - prompt_latent.size(1)
                     if start_index < 0:
-                        latent_history[:] = prompt_latent[:, -start_index:,:]
+                        latent_history[:] = prompt_latent[:, -start_index:, :]
                     else:
-                        latent_history[:, start_index:,:] = prompt_latent
-                    
-            # Predict the latent for the current timestep using the Flow Matching head, conditioned on the history and other inputs.
-            sampled_token_latent, trajectory = self.flowloss.sample(z_diff, latent_history, cfg, self.patch_size, sigma=sigma, temperature=temperature)
+                        latent_history[:, start_index:, :] = prompt_latent
+
+            sampled_token_latent, trajectory = self.flowloss.sample(
+                z_diff, latent_history, cfg, self.patch_size,
+                sigma=sigma, temperature=temperature
+            )
             result.append(sampled_token_latent)
 
-            # Check if the generation is complete.
             if self.stop_head(z_diff)[0][0].softmax(dim=-1)[1] > 0.5 and step > 3:
                 yield sampled_token_latent, True
                 break
@@ -457,7 +373,6 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
 
             inputs_embeds = self.linear_proj_audio(sampled_token_latent)
 
-            # Update position_ids, attention_mask, latent_history for next step
             if self.model_type == 'dense':
                 position_ids = position_ids[:, -1:] + 1
             else:
@@ -475,70 +390,55 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
 
             attention_mask = torch.ones(inputs_embeds.shape[0], 1).to(inputs_embeds.device)
             latent_history[:, :-self.patch_size, :] = latent_history[:, self.patch_size:, :].clone()
-            latent_history[:, -self.patch_size:, :] = sampled_token_latent[:]
+            latent_history[:, -self.patch_size:, :] = sampled_token_latent
 
     @torch.inference_mode()
-    def generate(
-        self,
-        prompt,
-        text,
-        spk_emb=None,
-        instruction=None,
-        prompt_waveform=None,
-        prompt_text=None,
-        max_decode_steps=200,
-        cfg=2.0,
-        sigma=0.25,
-        temperature=0,
-        use_zero_spk_emb=False
-    ):
+    def generate(self, prompt, text, spk_emb=None, instruction=None,
+                 prompt_waveform=None, prompt_text=None, max_decode_steps=200,
+                 cfg=2.0, sigma=0.25, temperature=0, use_zero_spk_emb=False):
+
+        # T4 float32 upgrade 
+        # from_pretrained() casts ALL parameters AND buffers (incl. ISTFT
+        # Hann window) in-place after __init__, so any dtype surgery in
+        # __init__ is silently undone. The only reliable fix on float16
+        # hardware is to upcast the entire model to float32 right here,
+        # before any computation. On bfloat16 hardware this branch is
+        # skipped entirely — zero cost, original performance preserved.
+        if self._infer_dtype == torch.float16:
+            logger.info("[dtype] T4: upcasting entire model to float32 for this call")
+            self.float()   # casts ALL params + buffers in one shot
+
         stream_state = (None, None, None)
         past_key_values = None
         use_cache = True
         speech = []
-        sampled_tokens_list = []
-        with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
-            for sampled_tokens, last_chunk in self.sample(
-                    prompt=prompt,
-                    text=text,
-                    spk_emb=spk_emb,
-                    instruction=instruction,
-                    prompt_waveform=prompt_waveform,
-                    prompt_text=prompt_text,
-                    max_decode_steps=max_decode_steps,
-                    cfg=cfg,
-                    sigma=sigma,
-                    temperature=temperature,
-                    use_zero_spk_emb=use_zero_spk_emb
-            ):
-                speech_tmp, stream_state, past_key_values = self.audio.decode(sampled_tokens, past_key_values=past_key_values, use_cache=use_cache, stream_state=stream_state, last_chunk=last_chunk)
-                speech.append(speech_tmp)
-                # For non-streaming decode
-                # sampled_tokens_list.append(sampled_tokens)
+
+        for sampled_tokens, last_chunk in self.sample(
+            prompt=prompt, text=text, spk_emb=spk_emb, instruction=instruction,
+            prompt_waveform=prompt_waveform, prompt_text=prompt_text,
+            max_decode_steps=max_decode_steps, cfg=cfg, sigma=sigma,
+            temperature=temperature, use_zero_spk_emb=use_zero_spk_emb,
+        ):
+            speech_tmp, stream_state, past_key_values = self.audio.decode(
+                sampled_tokens,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                stream_state=stream_state,
+                last_chunk=last_chunk,
+            )
+            speech.append(speech_tmp)
 
         speech = torch.cat(speech, dim=-1)
-
-        # # For non-streaming decode
-        # sampled_tokens = torch.cat(sampled_tokens_list, dim=1)
-        # with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
-        #     speech = self.audio.decode(sampled_tokens, past_key_values=None, use_cache=False)[0]
-
         return speech.cpu().float()[0]
-    
+
     @torch.inference_mode()
-    def generate_text(
-        self,
-        prompt,
-        text,
-        max_decode_steps=200,
-    ):
+    def generate_text(self, prompt, text, max_decode_steps=200):
+        assert self.model_type == 'dense', "Not supported for MoE model"
+        run_dtype = self._infer_dtype
         sampled_texts_list = []
-        with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
+        with torch.autocast(device_type='cuda', dtype=run_dtype):
             for sampled_tokens, last_chunk in self.sample_text(
-                    prompt=prompt,
-                    text=text,
-                    max_decode_steps=max_decode_steps,
+                prompt=prompt, text=text, max_decode_steps=max_decode_steps,
             ):
                 sampled_texts_list.append(sampled_tokens)
-
         return "".join(sampled_texts_list)

--- a/modeling_bailingmm.py
+++ b/modeling_bailingmm.py
@@ -23,12 +23,17 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
     _supports_flash_attn_2 = True
     _tied_weights_keys = ["model.lm_head.weight"]
 
-    def __init__(self, config: BailingMMConfig):
+    def __init__(
+        self, 
+        config: BailingMMConfig
+        ):
         super().__init__(config)
         self.config: BailingMMConfig = config
+
         self.model_type = config.model_type
 
-        # Dense Model: Qwen2.5-0.5B. MoE Model: Bailing-MoE-Lite-16.8B.
+        # Dense Model: Utilizes the Qwen2.5-0.5B model.
+        # MoE Model: Utilizes the Bailing-MoE-Lite-16.8B model.
         if self.model_type == 'dense':
             llm_config = Qwen2Config.from_dict(self.config.llm_config)
             self.model = Qwen2ForCausalLM(llm_config)
@@ -77,14 +82,18 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
         inputs_embeds=None
     ):
         use_abs_time_pos = second_per_grid_ts is not None
+
         mrope_position_deltas = []
         if image_grid_thw is not None or video_grid_thw is not None:
             total_input_ids = input_ids
             if attention_mask is None:
                 attention_mask = torch.ones_like(total_input_ids)
             position_ids = torch.ones(
-                3, input_ids.shape[0], input_ids.shape[1],
-                dtype=input_ids.dtype, device=input_ids.device,
+                3,
+                input_ids.shape[0],
+                input_ids.shape[1],
+                dtype=input_ids.dtype,
+                device=input_ids.device,
             )
             image_index, video_index = 0, 0
             attention_mask = attention_mask.to(total_input_ids.device)
@@ -92,13 +101,18 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 input_ids = input_ids[attention_mask[i] == 1]
                 image_nums, video_nums = 0, 0
                 if image_grid_thw is not None:
-                    vision_start_indices = torch.argwhere(input_ids == image_start_token_id).squeeze(1)
+                    vision_start_indices = torch.argwhere(
+                        input_ids == image_start_token_id
+                    ).squeeze(1)
                     vision_tokens = input_ids[vision_start_indices + 1]
                     image_nums = (vision_tokens == image_token_id).sum()
                 if video_grid_thw is not None:
-                    vision_start_indices = torch.argwhere(input_ids == video_start_token_id).squeeze(1)
+                    vision_start_indices = torch.argwhere(
+                        input_ids == video_start_token_id
+                    ).squeeze(1)
                     vision_tokens = input_ids[vision_start_indices + 1]
                     video_nums = (vision_tokens == video_token_id).sum()
+
                 input_tokens = input_ids.tolist()
                 llm_pos_ids_list: list = []
                 st = 0
@@ -113,47 +127,86 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                     else:
                         ed_video = len(input_tokens) + 1
                     if ed_image < ed_video:
-                        t, h, w = image_grid_thw[image_index][0], image_grid_thw[image_index][1], image_grid_thw[image_index][2]
+                        t, h, w = (
+                            image_grid_thw[image_index][0],
+                            image_grid_thw[image_index][1],
+                            image_grid_thw[image_index][2],
+                        )
                         second_per_grid_t = 0
                         image_index += 1
                         remain_images -= 1
                         ed = ed_image
+
                     else:
-                        t, h, w = video_grid_thw[video_index][0], video_grid_thw[video_index][1], video_grid_thw[video_index][2]
-                        second_per_grid_t = second_per_grid_ts[video_index] if second_per_grid_ts is not None else 1.0
+                        t, h, w = (
+                            video_grid_thw[video_index][0],
+                            video_grid_thw[video_index][1],
+                            video_grid_thw[video_index][2],
+                        )
+                        if second_per_grid_ts is not None:
+                            second_per_grid_t = second_per_grid_ts[video_index]
+                        else:
+                            second_per_grid_t = 1.0
                         video_index += 1
                         remain_videos -= 1
                         ed = ed_video
-                    llm_grid_t = t.item()
-                    llm_grid_h = h.item() // spatial_merge_size
-                    llm_grid_w = w.item() // spatial_merge_size
+                    llm_grid_t, llm_grid_h, llm_grid_w = (
+                        t.item(),
+                        h.item() // spatial_merge_size,
+                        w.item() // spatial_merge_size,
+                    )
                     text_len = ed - st
+
                     st_idx = llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
-                    llm_pos_ids_list.append(torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx)
+                    llm_pos_ids_list.append(
+                        torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                    )
+
                     range_tensor = torch.arange(llm_grid_t).view(-1, 1)
                     expanded_range = range_tensor.expand(-1, llm_grid_h * llm_grid_w)
                     if use_abs_time_pos:
-                        time_tensor_long = (expanded_range * second_per_grid_t * tokens_per_second).long()
+                        time_tensor = expanded_range * second_per_grid_t * tokens_per_second
+                        time_tensor_long = time_tensor.long()
                     else:
                         time_tensor_long = expanded_range.long()
                     t_index = time_tensor_long.flatten()
-                    h_index = torch.arange(llm_grid_h).view(1, -1, 1).expand(llm_grid_t, -1, llm_grid_w).flatten()
-                    w_index = torch.arange(llm_grid_w).view(1, 1, -1).expand(llm_grid_t, llm_grid_h, -1).flatten()
-                    llm_pos_ids_list.append(torch.stack([t_index, h_index, w_index]) + text_len + st_idx)
+
+                    h_index = (
+                        torch.arange(llm_grid_h)
+                        .view(1, -1, 1)
+                        .expand(llm_grid_t, -1, llm_grid_w)
+                        .flatten()
+                    )
+                    w_index = (
+                        torch.arange(llm_grid_w)
+                        .view(1, 1, -1)
+                        .expand(llm_grid_t, llm_grid_h, -1)
+                        .flatten()
+                    )
+                    llm_pos_ids_list.append(
+                        torch.stack([t_index, h_index, w_index]) + text_len + st_idx
+                    )
                     st = ed + llm_grid_t * llm_grid_h * llm_grid_w
+
                 if st < len(input_tokens):
                     st_idx = llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
                     text_len = len(input_tokens) - st
-                    llm_pos_ids_list.append(torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx)
+                    llm_pos_ids_list.append(
+                        torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx
+                    )
+
                 llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
                 position_ids[..., i, attention_mask[i] == 1] = llm_positions.to(position_ids.device)
                 mrope_position_deltas.append(llm_positions.max() + 1 - len(total_input_ids[i]))
-            mrope_position_deltas = torch.tensor(mrope_position_deltas, device=input_ids.device).unsqueeze(1)
+            mrope_position_deltas = torch.tensor(
+                mrope_position_deltas, device=input_ids.device
+            ).unsqueeze(1)
         else:
             device = inputs_embeds.device if inputs_embeds is not None else input_ids.device
             length = inputs_embeds.size(1) if inputs_embeds is not None else input_ids.size(1)
             bsz = inputs_embeds.size(0) if inputs_embeds is not None else input_ids.size(0)
             dtype = inputs_embeds.dtype if inputs_embeds is not None else input_ids.dtype
+
             if attention_mask is not None:
                 position_ids = attention_mask.long().cumsum(-1) - 1
                 position_ids.masked_fill_(attention_mask == 0, 1)
@@ -161,8 +214,17 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 max_position_ids = position_ids.max(0, keepdim=False)[0].max(-1, keepdim=True)[0]
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
-                position_ids = torch.arange(length, device=device).view(1, 1, -1).expand(3, bsz, -1)
-                mrope_position_deltas = torch.zeros([bsz, 1], device=device, dtype=dtype)
+                position_ids = (
+                    torch.arange(length, device=device)
+                    .view(1, 1, -1)
+                    .expand(3, bsz, -1)
+                )
+                mrope_position_deltas = torch.zeros(
+                    [bsz, 1],
+                    device=device,
+                    dtype=dtype,
+                )
+
         return position_ids, mrope_position_deltas
 
     def prepare_inputs_for_generation(self):
@@ -350,7 +412,8 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                 video_token_id=self.config.llm_config.image_patch_token,
                 image_start_token_id=self.config.llm_config.image_start_token,
                 video_start_token_id=self.config.llm_config.video_start_token,
-                image_grid_thw=None, video_grid_thw=None,
+                image_grid_thw=None, 
+                video_grid_thw=None,
                 attention_mask=attention_mask,
             )
             self.rope_deltas = rope_deltas
@@ -388,10 +451,7 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                         latent_history[:, start_index:, :] = prompt_latent
 
             # Predict the latent for the current timestep using the Flow Matching head, conditioned on the history and other inputs.
-            sampled_token_latent, trajectory = self.flowloss.sample(
-                z_diff, latent_history, cfg, self.patch_size,
-                sigma=sigma, temperature=temperature
-            )
+            sampled_token_latent, trajectory = self.flowloss.sample(z_diff, latent_history, cfg, self.patch_size, sigma=sigma, temperature=temperature)
             result.append(sampled_token_latent)
 
             # Check if the generation is complete.
@@ -421,7 +481,7 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
 
             attention_mask = torch.ones(inputs_embeds.shape[0], 1).to(inputs_embeds.device)
             latent_history[:, :-self.patch_size, :] = latent_history[:, self.patch_size:, :].clone()
-            latent_history[:, -self.patch_size:, :] = sampled_token_latent
+            latent_history[:, -self.patch_size:, :] = sampled_token_latent[:]
 
     @torch.inference_mode()
     def generate(
@@ -457,9 +517,7 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
                     temperature=temperature,
                     use_zero_spk_emb=use_zero_spk_emb
             ):
-                speech_tmp, stream_state, past_key_values = self.audio.decode(
-                    sampled_tokens, past_key_values=past_key_values, use_cache=use_cache, stream_state=stream_state, last_chunk=last_chunk
-                )
+                speech_tmp, stream_state, past_key_values = self.audio.decode(sampled_tokens, past_key_values=past_key_values, use_cache=use_cache, stream_state=stream_state, last_chunk=last_chunk)
                 speech.append(speech_tmp)
                 # For non-streaming decode
                 # sampled_tokens_list.append(sampled_tokens)

--- a/modeling_bailingmm.py
+++ b/modeling_bailingmm.py
@@ -53,27 +53,14 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
         self.spk_head = nn.Linear(192, self.model.config.hidden_size, bias=True)
         self.post_init()
 
-    # dtype strategy 
-    # 1. BFLOAT16 (A100/H100/L4): Fast path. 8-bit exponent matches FP32;
-    #    ISTFT complex math and ODE solvers are numerically safe here.
-    # 
-    # 2. FLOAT16 (T4/Legacy): 5-bit exponent (max ~65k) is a death trap for 
-    #    audio spectrograms and ODE trajectories. Results in ComplexHalf NaN.
-    #
-    # 3. WHY FULL FP32 ON T4? 
-    #    - Transformers `from_pretrained` overwrites granular `module.float()` 
-    #      calls in-place post-init. 
-    #    - Buffer mismatches (e.g. Hann window) trigger NaNs even if weights 
-    #      are FP32.
-    #    - Memory Trade-off: 0.5B LLM adds ~1GB overhead.
-    #
-    #   generate() detects fp16 and casts the whole model to fp32 once per
-    #   call via self.float(). autocast is skipped on the fp16 path.
-
     @property
     def _infer_dtype(self) -> torch.dtype:
-        """Read actual dtype from LLM backbone params — truth after from_pretrained."""
         return next(self.model.parameters()).dtype
+
+    def _autocast_context(self):
+        enabled = self.device.type == 'cuda' and self._infer_dtype in (torch.float16, torch.bfloat16)
+        dtype = self._infer_dtype if enabled else torch.bfloat16
+        return torch.autocast(device_type=self.device.type, dtype=dtype, enabled=enabled)
 
     def get_rope_index(
         self,
@@ -182,8 +169,10 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
     def prepare_inputs_for_generation(self):
         pass
 
-    def prepare_input_embed(self, prompt, text, spk_emb=None, instruction=None,
-                            prompt_latent=None, prompt_text=None, use_zero_spk_emb=False):
+    def prepare_input_embed(self, prompt, text, spk_emb=None, instruction=None,prompt_latent=None, prompt_text=None, use_zero_spk_emb=False):
+        """
+        Prepares the input embeddings for the model by constructing a complex sequence of text tokens and injecting continuous features like speaker embeddings and audio latents.
+        """
         spk_emb_prompt = []
         if spk_emb is not None:
             for i, se in enumerate(spk_emb):
@@ -268,6 +257,7 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
             audio_token_id = self.tokenizer.convert_tokens_to_ids("<audio>")
             audio_indices = torch.where(input_ids[0] == audio_token_id)[0]
             assert len(audio_indices) > 0
+            # 只考虑batchsize=1
             inputs_embeds[0, audio_indices[0] + 1:audio_indices[0] + 1 + prompt_latent.size(1), :] = prompt_latent[0]
 
         return input_ids, inputs_embeds
@@ -325,13 +315,11 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
             )
             self.rope_deltas = rope_deltas
 
-        # Use actual dtype from params (post from_pretrained)
-        run_dtype = self._infer_dtype
         past_key_values = None
         result = []
 
         for step in tqdm(range(max_decode_steps)):
-            with torch.autocast(device_type='cuda', dtype=run_dtype):
+            with self._autocast_context():
                 outputs = self.model(
                     attention_mask=attention_mask,
                     position_ids=position_ids,
@@ -396,49 +384,49 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
     def generate(self, prompt, text, spk_emb=None, instruction=None,
                  prompt_waveform=None, prompt_text=None, max_decode_steps=200,
                  cfg=2.0, sigma=0.25, temperature=0, use_zero_spk_emb=False):
-
-        # T4 float32 upgrade 
-        # from_pretrained() casts ALL parameters AND buffers (incl. ISTFT
-        # Hann window) in-place after __init__, so any dtype surgery in
-        # __init__ is silently undone. The only reliable fix on float16
-        # hardware is to upcast the entire model to float32 right here,
-        # before any computation. On bfloat16 hardware this branch is
-        # skipped entirely — zero cost, original performance preserved.
         if self._infer_dtype == torch.float16:
-            logger.info("[dtype] T4: upcasting entire model to float32 for this call")
-            self.float()   # casts ALL params + buffers in one shot
+            logger.info("[dtype] T4: upcasting model to float32 for this call")
+            self.float()
 
         stream_state = (None, None, None)
         past_key_values = None
         use_cache = True
         speech = []
+        sampled_tokens_list = []
 
-        for sampled_tokens, last_chunk in self.sample(
-            prompt=prompt, text=text, spk_emb=spk_emb, instruction=instruction,
-            prompt_waveform=prompt_waveform, prompt_text=prompt_text,
-            max_decode_steps=max_decode_steps, cfg=cfg, sigma=sigma,
-            temperature=temperature, use_zero_spk_emb=use_zero_spk_emb,
-        ):
-            speech_tmp, stream_state, past_key_values = self.audio.decode(
-                sampled_tokens,
-                past_key_values=past_key_values,
-                use_cache=use_cache,
-                stream_state=stream_state,
-                last_chunk=last_chunk,
-            )
-            speech.append(speech_tmp)
+        with self._autocast_context():
+            for sampled_tokens, last_chunk in self.sample(
+                    prompt=prompt,
+                    text=text,
+                    spk_emb=spk_emb,
+                    instruction=instruction,
+                    prompt_waveform=prompt_waveform,
+                    prompt_text=prompt_text,
+                    max_decode_steps=max_decode_steps,
+                    cfg=cfg,
+                    sigma=sigma,
+                    temperature=temperature,
+                    use_zero_spk_emb=use_zero_spk_emb
+            ):
+                speech_tmp, stream_state, past_key_values = self.audio.decode(
+                    sampled_tokens, past_key_values=past_key_values, use_cache=use_cache, stream_state=stream_state, last_chunk=last_chunk
+                )
+                speech.append(speech_tmp)
+                # For non-streaming decode
+                # sampled_tokens_list.append(sampled_tokens)
 
         speech = torch.cat(speech, dim=-1)
         return speech.cpu().float()[0]
 
     @torch.inference_mode()
     def generate_text(self, prompt, text, max_decode_steps=200):
-        assert self.model_type == 'dense', "Not supported for MoE model"
-        run_dtype = self._infer_dtype
         sampled_texts_list = []
-        with torch.autocast(device_type='cuda', dtype=run_dtype):
+        with self._autocast_context():
             for sampled_tokens, last_chunk in self.sample_text(
-                prompt=prompt, text=text, max_decode_steps=max_decode_steps,
+                    prompt=prompt,
+                    text=text,
+                    max_decode_steps=max_decode_steps,
             ):
                 sampled_texts_list.append(sampled_tokens)
+
         return "".join(sampled_texts_list)

--- a/modeling_bailingmm.py
+++ b/modeling_bailingmm.py
@@ -3,6 +3,8 @@
 # Copyright (c) Ant Group. All rights reserved.
 import torch
 import torch.nn as nn
+import hashlib
+import os
 from tqdm import tqdm
 from transformers import PreTrainedModel, Qwen2ForCausalLM, Qwen2Config
 from loguru import logger
@@ -452,6 +454,20 @@ class BailingMMNativeForConditionalGeneration(PreTrainedModel):
 
             # Predict the latent for the current timestep using the Flow Matching head, conditioned on the history and other inputs.
             sampled_token_latent, trajectory = self.flowloss.sample(z_diff, latent_history, cfg, self.patch_size, sigma=sigma, temperature=temperature)
+            if os.environ.get("MING_DEBUG_PARITY") == "1" and step == 0:
+                flat_patch = sampled_token_latent.detach().to(dtype=torch.float32).reshape(-1).cpu().contiguous()
+                logger.info(
+                    "MING_UPSTREAM_STAGE0_PARITY {}",
+                    {
+                        "shape": tuple(sampled_token_latent.shape),
+                        "mean": float(flat_patch.mean().item()),
+                        "std": float(flat_patch.std(unbiased=False).item()),
+                        "min": float(flat_patch.min().item()),
+                        "max": float(flat_patch.max().item()),
+                        "first8": flat_patch[:8].tolist(),
+                        "sha256_fp32": hashlib.sha256(flat_patch.numpy().tobytes()).hexdigest(),
+                    },
+                )
             result.append(sampled_token_latent)
 
             # Check if the generation is complete.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ torch==2.6.0
 torchaudio==2.6.0
 torchvision==0.21.0
 tokenizers==0.21.4
+gradio>=5.0.0
 grouped_gemm==0.1.4
 peft==0.17.1
 diffusers==0.33.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ torchaudio==2.6.0
 torchvision==0.21.0
 tokenizers==0.21.4
 gradio>=5.0.0
-grouped_gemm==0.1.4
+# grouped_gemm==0.1.4
 peft==0.17.1
 diffusers==0.33.0
 decord==0.6.0


### PR DESCRIPTION
- add Tesla T4 fallback for environments without native bfloat16
- upcast to float32 at generate time to avoid NaN audio on float16 hardware
- add flash-attn fallback to native PyTorch scaled_dot_product_attention
- include Gradio demo for easier local testing
- preserve original bfloat16 path on supported GPUs